### PR TITLE
fix: anthropic usage from API response

### DIFF
--- a/packages/core/src/core/llm-client.ts
+++ b/packages/core/src/core/llm-client.ts
@@ -127,16 +127,17 @@ export class LLMClient {
         temperature: this.config.temperature,
         messages: [{ role: "user", content: prompt }],
       },
-      { signal }
+      { signal },
     );
 
     return {
       text: response.content[0].type === "text" ? response.content[0].text : "",
       model: this.currentModel,
       usage: {
-        prompt_tokens: 0, // Anthropic doesn't provide token counts
-        completion_tokens: 0,
-        total_tokens: 0,
+        prompt_tokens: response.usage.input_tokens,
+        completion_tokens: response.usage.output_tokens,
+        total_tokens: response.usage.input_tokens +
+          response.usage.output_tokens,
       },
       metadata: {
         stop_reason: response.stop_reason,


### PR DESCRIPTION
The Anthropic API does respond with the number of tokens used. It is `response.messages.usage` as a [Usage](https://github.com/anthropics/anthropic-sdk-typescript/blob/dc2591fcc8847d509760a61777fc1b79e0eab646/src/resources/messages/messages.ts#L548) interfaces. This PR incorporates it to DD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved token usage tracking for Anthropic API calls by accurately capturing input and output token counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->