### PR TITLE
fix: no apiKey in logs

### DIFF
--- a/packages/core/src/core/llm-client.ts
+++ b/packages/core/src/core/llm-client.ts
@@ -69,6 +69,32 @@ export class LLMClient {
     });
   }
 
+  // obfuscate the API key when logging
+  toJSON() {
+    let maskedApiKey = this.config.apiKey.slice(0, 7) + "*".repeat(3);
+
+    return {
+      ...this,
+      config: {
+        ...this.config,
+        apiKey: maskedApiKey,
+      },
+      anthropic: this.anthropic && {
+        ...this.anthropic,
+        apiKey: maskedApiKey,
+        _options: {
+          // @ts-ignore
+          ...this.anthropic._options,
+          apiKey: maskedApiKey,
+        },
+      },
+    };
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    return this.toJSON();
+  }
+
   public async complete(prompt: string): Promise<LLMResponse> {
     let lastError: Error | null = null;
 


### PR DESCRIPTION
console.logging an LLMClient instance exposes the `apiKey` which can leak to logs e.g. in a live coding session or just propagate somewhere randomly. This PR prevents that, logging of the apiKey prints just sth like `sk-ant-***` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
	- Enhanced logging security by masking API keys when generating JSON representations of the LLM client
	- Prevents accidental exposure of sensitive authentication credentials during logging and inspection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->