### PR TITLE
fix: use config values in analyze()

### DIFF
--- a/packages/core/src/core/llm-client.ts
+++ b/packages/core/src/core/llm-client.ts
@@ -188,8 +188,8 @@ export class LLMClient {
   ): Promise<string | StructuredAnalysis> {
     const {
       system,
-      temperature = 0.3,
-      maxTokens = 1500,
+      temperature = this.config.temperature,
+      maxTokens = this.config.maxTokens,
       formatResponse = false,
     } = options;
 


### PR DESCRIPTION
When calling `LLMClient.analyze()` the `temperature` and `maxTokens` default values are hardcoded. This PR updates the code so the values are taken from `this.config`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated default temperature and max tokens in the LLM client to use configuration settings.
	- Improved flexibility for configuring AI analysis parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->