### PR TITLE
feat: add separate contract read action handler

### DIFF
--- a/packages/core/src/core/actions/starknet-read.ts
+++ b/packages/core/src/core/actions/starknet-read.ts
@@ -1,0 +1,8 @@
+import type { ActionHandler } from "../../types";
+import { executeStarknetRead } from "../providers";
+import type { CoTTransaction } from "../../types";
+
+export const starknetReadAction: ActionHandler = async (action, chain) => {
+  const result = await executeStarknetRead(action.payload as CoTTransaction);
+  return `Contract read executed successfully: ${JSON.stringify(result, null, 2)}`;
+}; 

--- a/packages/core/src/core/providers.ts
+++ b/packages/core/src/core/providers.ts
@@ -69,6 +69,15 @@ export const getStarknetAccount = () => {
   );
 };
 
+export const executeStarknetRead = async (call: Call): Promise<any> => {
+  try {
+    call.calldata = CallData.compile(call.calldata || []);
+    return await getStarknetProvider().callContract(call);
+  } catch (error) {
+    return error instanceof Error ? error : new Error("Unknown error occurred");
+  }
+};
+
 export const executeStarknetTransaction = async (call: Call): Promise<any> => {
   try {
     call.calldata = CallData.compile(call.calldata || []);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -140,6 +140,7 @@ export interface ChainOfThoughtContext {
 export type CoTActionType =
   | "GRAPHQL_FETCH"
   | "EXECUTE_TRANSACTION"
+  | "READ_CONTRACT"
   | "SYSTEM_PROMPT";
 
 /**


### PR DESCRIPTION
Add separate contract read action handler

Changes:
- Add `executeStarknetRead` function in providers.ts to handle contract reads using `provider.callContract()`
- Create new `starknet-read.ts` action handler for read operations
- Keep `READ_CONTRACT` as distinct action type from `EXECUTE_TRANSACTION`

This change provides clean separation between read and write operations:
- Read operations use `provider.callContract()` (no gas fees)
- Write operations use `account.execute()` (requires signing, costs gas)

The separation makes it clearer for the LLM to choose the appropriate action type based on whether it needs to read state or modify it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for reading from StarkNet contracts
	- Introduced a new action type "READ_CONTRACT" to enable contract read operations

- **Improvements**
	- Enhanced action handling capabilities for blockchain interactions
	- Implemented robust error handling for contract read operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->