### PR TITLE
refactor: removes redundant model string

### DIFF
--- a/packages/core/src/core/llm-client.ts
+++ b/packages/core/src/core/llm-client.ts
@@ -44,7 +44,6 @@ interface StructuredAnalysis {
 export class LLMClient {
   private anthropic?: Anthropic;
   private readonly config: Required<LLMClientConfig>;
-  private currentModel: string;
 
   constructor(config: LLMClientConfig) {
     this.config = {
@@ -59,7 +58,6 @@ export class LLMClient {
       maxDelay: config.maxDelay || 10000,
     };
 
-    this.currentModel = this.config.model;
     this.initializeClient();
   }
 
@@ -92,11 +90,11 @@ export class LLMClient {
   }
 
   public getModelName(): string {
-    return this.currentModel;
+    return this.config.model;
   }
 
   public getModelVersion(): string {
-    const versionMatch = this.currentModel.match(/\d+(\.\d+)*/);
+    const versionMatch = this.config.model.match(/\d+(\.\d+)*/);
     return versionMatch ? versionMatch[0] : "unknown";
   }
 
@@ -104,7 +102,7 @@ export class LLMClient {
     const controller = new AbortController();
     const timeoutId = globalThis.setTimeout(
       () => controller.abort(),
-      this.config.timeout
+      this.config.timeout,
     );
 
     try {
@@ -122,7 +120,7 @@ export class LLMClient {
 
     const response = await this.anthropic.messages.create(
       {
-        model: this.currentModel,
+        model: this.config.model,
         max_tokens: this.config.maxTokens,
         temperature: this.config.temperature,
         messages: [{ role: "user", content: prompt }],
@@ -132,7 +130,7 @@ export class LLMClient {
 
     return {
       text: response.content[0].type === "text" ? response.content[0].text : "",
-      model: this.currentModel,
+      model: this.config.model,
       usage: {
         prompt_tokens: 0, // Anthropic doesn't provide token counts
         completion_tokens: 0,
@@ -194,7 +192,7 @@ export class LLMClient {
     } = options;
 
     const response = await this.anthropic?.messages.create({
-      model: this.currentModel,
+      model: this.config.model,
       messages: [
         {
           role: "assistant",


### PR DESCRIPTION
Removing `currentModel` form LLMClient as it can be obtained from the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified model configuration by removing redundant `currentModel` property
	- Updated methods to directly use model configuration from `config.model`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->