### PR TITLE
fix: use of system prompt

### DIFF
--- a/packages/core/src/core/llm-client.ts
+++ b/packages/core/src/core/llm-client.ts
@@ -220,11 +220,8 @@ export class LLMClient {
 
     const response = await this.anthropic?.messages.create({
       model: this.config.model,
+      system: system || "",
       messages: [
-        {
-          role: "assistant",
-          content: system || "",
-        },
         {
           role: "user",
           content: formatResponse


### PR DESCRIPTION
The way to set a system prompt for Claude is via a designated `system` parameter, not as a message with an "assistant" role (that actually tells Claude that that message was his response). This PR fixes the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified the message structure when sending requests to the Anthropic API.
	- Improved system prompt handling in the LLM client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->