### PR TITLE
feat: chain of responsibility

### DIFF
--- a/examples/example-chat.ts
+++ b/examples/example-chat.ts
@@ -1,0 +1,163 @@
+// running this example expects ANTHROPIC_API_KEY env to be set
+
+import {
+    BaseIO,
+    Core,
+    Input,
+    Output,
+    Processor,
+    ProcessorFn,
+} from "../packages/core/src/core/core";
+import * as readline from "readline";
+import { Anthropic } from "@anthropic-ai/sdk";
+
+interface Message {
+    role: "user" | "assistant";
+    content: string;
+}
+
+interface ChatInput extends BaseIO {
+    type: "chat";
+    message: string;
+    history?: Message[];
+}
+
+interface ChatOutput extends BaseIO {
+    type: "chat";
+    message: string;
+}
+
+class MemoryProcessor implements Processor<ChatInput, ChatOutput> {
+    private history: Message[] = [];
+
+    async handle(
+        input: Input<ChatInput>,
+        next: ProcessorFn<ChatInput, ChatOutput>,
+    ): Promise<Output<ChatInput, ChatOutput>> {
+        // add history
+        const inputWithHistory: Input<ChatInput> = {
+            ...input,
+            content: {
+                ...input.content,
+                history: this.history,
+            },
+        };
+
+        // process the input
+        const output = await next(inputWithHistory);
+
+        // if we have a successful response, update the history
+        if (output.content) {
+            this.history.push(
+                { role: "user", content: input.content.message },
+                { role: "assistant", content: output.content.message },
+            );
+        }
+
+        return output;
+    }
+}
+
+class AnthropicProcessor implements Processor<ChatInput, ChatOutput> {
+    private client: Anthropic;
+
+    constructor(apiKey: string) {
+        this.client = new Anthropic({ apiKey });
+    }
+
+    async handle(
+        input: Input<ChatInput>,
+        next: ProcessorFn<ChatInput, ChatOutput>,
+    ): Promise<Output<ChatInput, ChatOutput>> {
+        try {
+            const messages = input.content.history?.map((msg) => ({
+                role: msg.role,
+                content: msg.content,
+            })) || [];
+
+            // Add the current message
+            messages.push({ role: "user", content: input.content.message });
+
+            const response = await this.client.messages.create({
+                model: "claude-3-5-sonnet-latest",
+                messages,
+                max_tokens: 1024,
+            });
+
+            return {
+                input,
+                content: {
+                    type: "chat",
+                    message: response.content[0].text,
+                },
+            };
+        } catch (error) {
+            return {
+                input,
+                content: null,
+                error: error instanceof Error
+                    ? error
+                    : new Error(String(error)),
+            };
+        }
+    }
+}
+
+async function main() {
+    const core = new Core<ChatInput, ChatOutput>();
+
+    core.registerProcessor(
+        new AnthropicProcessor(process.env.ANTHROPIC_API_KEY!),
+    );
+    core.registerProcessor(new MemoryProcessor());
+
+    const repl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    const chat = () => {
+        repl.question("> ", async (line) => {
+            if (line.toLowerCase() === "exit") {
+                repl.close();
+                process.exit(0);
+            }
+
+            try {
+                const input: Input<ChatInput> = {
+                    name: "repl",
+                    content: {
+                        type: "chat",
+                        message: line,
+                    },
+                };
+
+                const output = await core.process(input);
+
+                if (output.error) {
+                    console.error("Error:", output.error);
+                } else if (output.content) {
+                    console.log("\nA:", output.content.message, "\n");
+                }
+            } catch (error) {
+                console.error("Error:", error);
+            }
+
+            chat();
+        });
+    };
+
+    console.log("You are now chatting with Claude. Type 'exit' to quit.");
+    chat();
+
+    // cleanup
+    process.on("SIGINT", () => {
+        repl.close();
+        process.exit(0);
+    });
+}
+
+main().catch((error) => {
+    console.error(console.log("Fatal error:"), error);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "twitter": "bun run examples/example-twitter.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.33.1",
     "@types/node": "^22.10.5",
     "ajv": "^8.17.1",
     "chalk": "^5.4.1",

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -1,257 +1,104 @@
-import { Logger } from "./logger";
-import { Room } from "./room";
-import { RoomManager } from "./room-manager";
-import type { VectorDB } from "./vector-db";
-import { LogLevel } from "../types";
-import type { JSONSchemaType } from "ajv";
-import type { Processor } from "./processor";
+export interface BaseIO {
+  type: string;
+}
 
-// Input interface for scheduled or one-time tasks
-export interface Input {
+// generic input type
+export interface Input<TContent extends BaseIO> {
   name: string;
-  handler: (...args: any[]) => Promise<any>;
-  response: any; // Type of response expected
-  interval?: number; // Time in milliseconds between runs, if not provided runs once
+  content: TContent;
 }
 
-// Output interface for actions that push data somewhere
-export interface Output {
-  name: string;
-  handler: (data: any) => Promise<any>;
-  response: any; // Type of response expected
-  schema: JSONSchemaType<any>; // Schema to validate input data
+// generic output type
+export interface Output<TInput extends BaseIO, TContent extends BaseIO> {
+  input: Input<TInput>;
+  content: TContent | null;
+  error?: Error;
 }
 
-export interface CoreConfig {
-  logging?: {
-    level: LogLevel;
-    enableColors?: boolean;
-    enableTimestamp?: boolean;
-  };
+// Generic ProcessorFn type
+export type ProcessorFn<TInput extends BaseIO, TOutput extends BaseIO> = (
+  input: Input<TInput>,
+) => Promise<Output<TInput, TOutput>>;
+
+// Base Processor interface that works with any message type
+export interface Processor<TInput extends BaseIO, TOutput extends BaseIO> {
+  handle(
+    input: Input<TInput>,
+    next: ProcessorFn<TInput, TOutput>,
+  ): Promise<Output<TInput, TOutput>>;
 }
 
-export class Core {
-  private inputs: Map<string, Input & { lastRun?: number }> = new Map();
-  private outputs: Map<string, Output> = new Map();
-  private logger: Logger;
-  private roomManager: RoomManager;
-  private processor: Processor;
-  public readonly vectorDb: VectorDB;
+export class Core<TInput extends BaseIO, TOutput extends BaseIO> {
+  private processors: Processor<TInput, TOutput>[] = [];
 
-  constructor(
-    roomManager: RoomManager,
-    vectorDb: VectorDB,
-    processor: Processor,
-    config?: CoreConfig
-  ) {
-    this.roomManager = roomManager;
-    this.vectorDb = vectorDb;
-    this.logger = new Logger(
-      config?.logging ?? {
-        level: LogLevel.INFO,
-        enableColors: true,
-        enableTimestamp: true,
-      }
+  public registerProcessor(processor: Processor<TInput, TOutput>) {
+    this.processors.push(processor);
+  }
+
+  public async process(input: Input<TInput>): Promise<Output<TInput, TOutput>> {
+    // Create the chain of processor functions
+    const chain = this.processors.reduceRight(
+      (
+        next: ProcessorFn<TInput, TOutput>,
+        processor: Processor<TInput, TOutput>,
+      ) => {
+        return (input: Input<TInput>) => processor.handle(input, next);
+      },
+      // final handler that creates the Output
+      (input: Input<TInput>) =>
+        Promise.resolve({ input, content: null }) as Promise<
+          Output<TInput, TOutput>
+        >,
     );
 
-    this.processor = processor;
-
-    // Start input processing loop
-    this.processInputs();
-
-    // Register available outputs with processor
-    this.outputs.forEach((output) => {
-      this.processor.registerAvailableOutput(output);
-    });
-  }
-
-  /**
-   * Register a new input source
-   */
-  public registerInput(input: Input): void {
-    this.logger.info("Core.registerInput", "Registering input", {
-      name: input.name,
-    });
-
-    this.inputs.set(input.name, input);
-  }
-
-  /**
-   * Register a new output destination
-   */
-  public registerOutput(output: Output): void {
-    this.logger.info("Core.registerOutput", "Registering output", {
-      name: output.name,
-    });
-
-    this.outputs.set(output.name, output);
-  }
-
-  /**
-   * Process registered inputs on intervals
-   */
-  private async processInputs(): Promise<void> {
-    while (true) {
-      for (const [name, input] of this.inputs.entries()) {
-        const now = Date.now();
-
-        // Skip if not ready to run again
-        if (
-          input.interval &&
-          input.lastRun &&
-          now - input.lastRun < input.interval
-        ) {
-          continue;
-        }
-
-        try {
-          this.logger.debug("Core.processInputs", "Processing input", { name });
-
-          const result = await input.handler();
-
-          // Update last run time
-          this.inputs.set(name, {
-            ...input,
-            lastRun: now,
-          });
-
-          // Store result in room memory
-          if (result) {
-            const room = await this.ensureRoom(name);
-
-            const processed = await this.processor.process(result, room);
-
-            await this.roomManager.addMemory(
-              room.id,
-              JSON.stringify(processed.content), // TODO: Fix this everything being dumped into memory
-              {
-                source: name,
-                type: "input",
-                ...processed.metadata,
-                ...processed.enrichedContext,
-              }
-            );
-
-            // Handle suggested outputs
-            for (const suggestion of processed.suggestedOutputs) {
-              if (suggestion.confidence >= 0.7) {
-                // Configurable threshold
-                try {
-                  this.logger.info(
-                    "Core.processInputs",
-                    "Executing suggested output",
-                    {
-                      name: suggestion.name,
-                      confidence: suggestion.confidence,
-                      reasoning: suggestion.reasoning,
-                    }
-                  );
-                  await this.executeOutput(suggestion.name, suggestion.data);
-                } catch (error) {
-                  this.logger.error(
-                    "Core.processInputs",
-                    "Error executing suggested output",
-                    { error }
-                  );
-                }
-              }
-            }
-          }
-        } catch (error) {
-          this.logger.error("Core.processInputs", "Error processing input", {
-            name,
-            error,
-          });
-        }
-      }
-
-      // Small delay between iterations
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-  }
-
-  /**
-   * Execute an output with data
-   */
-  public async executeOutput(name: string, data: any): Promise<any> {
-    const output = this.outputs.get(name);
-    if (!output) {
-      throw new Error(`No output registered with name: ${name}`);
-    }
-
-    // Validate data against schema
-    try {
-      const Ajv = require("ajv");
-      const ajv = new Ajv();
-      const validate = ajv.compile(output.schema);
-
-      if (!validate(data)) {
-        this.logger.error("Core.executeOutput", "Schema validation failed", {
-          name,
-          data,
-          errors: validate.errors,
-          schema: output.schema,
-        });
-        throw new Error(
-          `Invalid data for output ${name}: ${JSON.stringify(validate.errors)}`
-        );
-      }
-
-      this.logger.debug("Core.executeOutput", "Executing output", {
-        name,
-        data,
-        schema: output.schema,
-      });
-
-      const result = await output.handler(data);
-
-      // Store in room memory
-      const room = await this.ensureRoom(name);
-      const processed = await this.processor.process(result, room);
-
-      await this.roomManager.addMemory(room.id, processed.content, {
-        source: name,
-        type: "output",
-        ...processed.metadata,
-        ...processed.enrichedContext,
-      });
-
-      return result;
-    } catch (error) {
-      this.logger.error("Core.executeOutput", "Error executing output", {
-        name,
-        data,
-        error: error instanceof Error ? error.message : error,
-      });
-      throw error;
-    }
-  }
-
-  private async ensureRoom(name: string): Promise<Room> {
-    let room = await this.roomManager.getRoomByPlatformId(name, "core");
-
-    if (!room) {
-      room = await this.roomManager.createRoom(name, "core", {
-        name,
-        description: `Room for ${name}`,
-        participants: [],
-      });
-    }
-
-    return room;
-  }
-
-  /**
-   * Remove an input
-   */
-  public removeInput(name: string): void {
-    this.inputs.delete(name);
-  }
-
-  /**
-   * Remove an output
-   */
-  public removeOutput(name: string): void {
-    this.outputs.delete(name);
+    return chain(input);
   }
 }
+
+export class FunctionalProcessor<TInput extends BaseIO, TOutput extends BaseIO>
+  implements Processor<TInput, TOutput> {
+  constructor(
+    private fn: (
+      input: Input<TInput>,
+      next: ProcessorFn<TInput, TOutput>,
+    ) => Promise<Output<TInput, TOutput>>,
+  ) {}
+
+  async handle(
+    input: Input<TInput>,
+    next: ProcessorFn<TInput, TOutput>,
+  ): Promise<Output<TInput, TOutput>> {
+    return this.fn(input, next);
+  }
+}
+
+// specialized processor that only handles specific message types
+// abstract class SpecializedProcessor<
+//   THandleInput extends BaseIO,
+//   TInput extends BaseIO,
+//   TOutput extends BaseIO
+// > implements Processor<TInput, TOutput> {
+
+//   async handle(
+//     input: Input<TInput>,
+//     next: ProcessorFn<TInput, TOutput>
+//   ): Promise<Output<TInput, TOutput>> {
+//     // Check if this input is the type we handle
+//     if (this.canHandle(input.content)) {
+//       return this.handleSpecific(
+//         input as Input<THandleInput>,
+//         next as ProcessorFn<THandleInput, TOutput>
+//       );
+//     }
+
+//     // Pass through if we don't handle this type
+//     return next(input);
+//   }
+
+//   protected abstract canHandle(content: TInput): content is THandleInput;
+
+//   protected abstract handleSpecific(
+//     input: Input<THandleInput>,
+//     next: ProcessorFn<THandleInput, TOutput>
+//   ): Promise<Output<TInput, TOutput>>;
+// }


### PR DESCRIPTION
Introduces a chain of responsibility pattern to handle inputs and outputs.

Core is now (so far) just a collection of processors. A processor is a class that takes in an Input, optionally modifies it and passes it down the chain until the bottom-most "null-content" processor (in Core.process) reverses the order - it creates an Output that this then passed up the chain. Each processor than has the chance to operate on the Output as well.

This is super powerful as all kind of processors can be added (as an example, the `MemoryProcesor` in example-chat that keeps the chat history and adds it to every request).

This approach also simplifies the processing as inputs can be handled out-of-order instead of looping through entries. There's no need for an `interval` on Input, the generation of an input should be handled by an external process outside of core (e.g. with `setInterval`).

Creating the PR as a draft to open up discussion.