### PR TITLE
Fix #17: Add rate limit to the Core class

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ STARKNET_PRIVATE_KEY=
 
 # This is the current GraphQL to make the examples work
 GRAPHQL_URL=https://api.cartridge.gg/x/sepolia-rc-18/torii
+
+# Optional: Set a minimum delay between Anthropic requests to prevent rate limits (eg 2000 and increase until resolved)
+ANTHROPIC_MIN_DELAY_MS=

--- a/packages/core/src/core/env.ts
+++ b/packages/core/src/core/env.ts
@@ -12,6 +12,10 @@ const envSchema = z.object({
   STARKNET_PRIVATE_KEY: z.string(),
 
   GRAPHQL_URL: z.string(),
+  ANTHROPIC_MIN_DELAY_MS: z
+  .string()
+  .optional()
+  .transform((val: string | undefined) => (val ? parseInt(val, 10) : 0)),
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
feat(core/env, llm-client): add optional ANTHROPIC_MIN_DELAY_MS env and minTimeBetweenRequestsMs config

- Adds optional 'ANTHROPIC_MIN_DELAY_MS' in env.ts, defaulting to 0 if blank.
- Extends LLMClient to accept and enforce minTimeBetweenRequestsMs from env.
- Logs debug info when delaying for rate-limit prevention.
- Ensures an empty env variable does not break the default behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration for minimum delay between Anthropic API requests to help prevent rate limits
	- Introduced logging functionality for LLM client interactions

- **Improvements**
	- Enhanced request management with configurable time intervals between API calls
	- Improved error handling and logging for LLM client

<!-- end of auto-generated comment: release notes by coderabbit.ai -->