### PR TITLE
fix: missing endpoint argument in new graphql api

### DIFF
--- a/examples/example-basic.ts
+++ b/examples/example-basic.ts
@@ -104,7 +104,11 @@ async function main() {
     name: "GRAPHQL_FETCH",
     handler: async (data: any) => {
       const { query, variables } = data.payload ?? {};
-      const result = await fetchGraphQL(query, variables);
+      const result = await fetchGraphQL(
+        env.GRAPHQL_URL + "/graphql",
+        query,
+        variables
+      );
       const resultStr = [
         `query: ${query}`,
         `result: ${JSON.stringify(result, null, 2)}`,

--- a/examples/example-goal.ts
+++ b/examples/example-goal.ts
@@ -130,7 +130,11 @@ async function main() {
     name: "GRAPHQL_FETCH",
     handler: async (data: any) => {
       const { query, variables } = data.payload ?? {};
-      const result = await fetchGraphQL(query, variables);
+      const result = await fetchGraphQL(
+        env.GRAPHQL_URL + "/graphql",
+        query,
+        variables
+      );
       const resultStr = [
         `query: ${query}`,
         `result: ${JSON.stringify(result, null, 2)}`,


### PR DESCRIPTION
Note: we could update GRAPHQL_URL in .env to include the /graphql suffix to avoid:

``` javascript
const result = await fetchGraphQL(
  env.GRAPHQL_URL + "/graphql",
  query,
  variables
);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated GraphQL fetch functionality to include a base URL from an environment variable
	- Improved GraphQL endpoint configuration by explicitly specifying the full GraphQL API URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->