### PR TITLE
fix: initialize goals without dependencies as ready

### DIFF
--- a/packages/core/src/core/chain-of-thought.ts
+++ b/packages/core/src/core/chain-of-thought.ts
@@ -269,6 +269,13 @@ export class ChainOfThought extends EventEmitter {
                 .map((id) => this.goalManager.getGoalById(id))
                 .filter((g): g is Goal => !!g);
 
+            // Update goals with no dependencies to ready
+            for (const goal of finalGoals) {
+                if (goal.dependencies && goal.dependencies.length === 0) {
+                    this.goalManager.updateGoalStatus(goal.id, "ready");
+                }
+            }
+
             // Add a planning step
             this.recordReasoningStep(
                 `Strategy planned for objective: ${objective}`,


### PR DESCRIPTION
Goals without dependencies are now initialized as "ready" instead of "pending". Previously, all goals defaulted to "pending", even those with no dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced goal management workflow by automatically marking goals without dependencies as "ready" immediately after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->