### PR TITLE
fix: added core package entry point

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
     "module": "index.ts",
     "version": "0.0.3",
     "type": "module",
+    "main": "dist/index.js",
     "devDependencies": {
         "@types/bun": "latest"
     },


### PR DESCRIPTION
The `@daydreamsai/core` package is missing an entry point.

The package requires an [main](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#main) or [exports](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#exports) entry.

> If main is not set, it defaults to index.js in the package's root folder.

Since it does not have an `index.js` file at its root, I added a `main` entry point, as it's got a single built product.

```sh
$ ls -l node_modules/@daydreamsai/core/
total 24
drwxr-xr-x   5 roger  staff   160 Jan 30 15:00 dist
drwxr-xr-x  25 roger  staff   800 Jan 30 14:57 node_modules
-rw-r--r--@  1 roger  staff  1656 Jan 30 15:07 package.json
drwxr-xr-x   4 roger  staff   128 Jan 30 14:57 src
-rw-r--r--   1 roger  staff   719 Jan 30 14:57 tsconfig.json
-rw-r--r--   1 roger  staff   167 Jan 30 14:57 tsup.config.ts

$ ls -l node_modules/@daydreamsai/core/dist/
total 1152
-rw-r--r--  1 roger  staff   76819 Jan 30 15:00 index.d.ts
-rw-r--r--  1 roger  staff  104337 Jan 30 15:00 index.js
-rw-r--r--  1 roger  staff  405162 Jan 30 15:00 index.js.map
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package configuration to specify the main entry point for the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->