### PR TITLE
dev: not overloading variable names

### DIFF
--- a/packages/core/src/core/v1/coe.ts
+++ b/packages/core/src/core/v1/coe.ts
@@ -61,7 +61,7 @@ export async function chainOfExperts({
     experts: { name: string; description: string }[];
     model: LanguageModelV1;
 }): Promise<any> {
-    const context = render(chainExpertManagerPrompt, {
+    const prompt = render(chainExpertManagerPrompt, {
         context: JSON.stringify(state),
         experts: experts
             .map((expert) =>
@@ -79,12 +79,11 @@ export async function chainOfExperts({
             .join("\n"),
     });
 
-    console.log({ context });
+    console.log({ prompt });
 
     const response = await llm({
         model,
-        system: context,
-        prompt: "<response>",
+        prompt,
         stopSequences: ["</response>"],
     });
 


### PR DESCRIPTION
Renaming `context` variable to `prompt` since 1) it's that and 2) `context` is overloaded in there.

Also sending the query to an LLM with the CoE prompt as prompt, not system.