### PR TITLE
feat(docs): add Awesome Daydreams to resources menu

### DIFF
--- a/docs/app/_meta.js
+++ b/docs/app/_meta.js
@@ -4,6 +4,16 @@ export default {
   "getting-started": "Getting Started",
   guides: "Guides",
   "api-reference": "API Reference",
+  resources: {
+    title: "Resources",
+    type: "menu",
+    items: {
+      awesome: {
+        title: "Awesome Daydreams",
+        href: "https://github.com/wayzeek/awesome-daydreams",
+      },
+    },
+  },
   contact: {
     title: "Contact",
     type: "menu",


### PR DESCRIPTION
Add Awesome Daydreams to the resources dropdown menu in the documentation navigation.

This PR:
- Adds a new Resources dropdown menu in the top navigation
- Includes a link to the Awesome Daydreams curated list of resources
- Places it logically after the API Reference section