### PR TITLE
Enable Local Compilation of @daydreams/core for Use in Examples

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from "tsup";
 
-import { tsupConfig } from "../../tsup.config";
-
 export default defineConfig({
-  ...tsupConfig,
-  entry: ["./src/index.ts", "src/extensions/index.ts"],
+  entry: {
+    "index": "src/index.ts",
+    "extensions/index": "src/extensions/index.ts",
+    "extensions/mcp/extension": "src/extensions/mcp/extension.ts",
+    "extensions/cli/extension": "src/extensions/cli/extension.ts",
+  },
   dts: true,
+  format: ["esm"],
+  clean: true,
+  splitting: true,
+  sourcemap: true,
+  outDir: "dist",
   external: ["readline/promises", "@tavily/core", "ollama"],
 });

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ We use [bun](https://bun.sh/) for development.
 ```bash
 bun install
 
-bun build:core --watch
+bun build:packages --watch
 ```
 
 Edit the core package and watch for changes, and play with examples.


### PR DESCRIPTION
Previously, packages/core could not be compiled to generate packages/core/extension/index.js. As a result, the examples module encountered an import error when referencing @daydreams/core/extensions:
```
Error: Cannot find module '@daydreams/core/extensions'
```
This issue can be observed in the following case:
[deep-research example](https://github.com/daydreamsai/daydreams/blob/main/examples/deep-research/index.ts#L2).

This PR resolves the issue by ensuring that @daydreams/core is correctly compiled and accessible within the examples directory.
