### PR TITLE
Update readme with deprecation notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,14 @@
 
 # Daydreams - AI Agent Framework
 
+> **Notice:** This agent framework is no longer the core focus as features are already obsolete.
+>
+> The Daydreams core focus is on Agentic Commerce and not the agent harness.
+>
+> Check out the lucid-agents repo: https://github.com/daydreamsai/lucid-agents
+>
+> We recommend the [Pi agent harness](https://github.com/badlogic/pi-mono) for building agents and incorporating [lucid-agents](https://github.com/daydreamsai/lucid-agents) in it.
+
 Finally, TypeScript agents that scale and compose
 
 🌐 [Website](https://dreams.fun) • ⚡ [Quick Start](#-quick-start) • 📖


### PR DESCRIPTION
Update the readme to clarify that the agent framework is no longer the core focus and direct users to lucid-agents and the Pi agent harness for building agents.

This adds a notice block at the top of the readme with links to the relevant repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect the project's strategic shift toward Agentic Commerce.
  * Added references to alternative resources and recommended tools for building agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->