### PR TITLE
feat(peer-cash): add peer cash extension for base usdc to fiat cash-outs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "daydreams",
@@ -201,6 +202,24 @@
         "@daydreamsai/core": "workspace:*",
         "crypto": "^1.0.1",
         "mongodb": "^6.14.2",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "tsup": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "typescript": "catalog:",
+      },
+    },
+    "packages/peer-cash": {
+      "name": "@daydreamsai/peer-cash",
+      "version": "0.3.22",
+      "dependencies": {
+        "@daydreamsai/core": "workspace:*",
+        "@zkp2p/cash": "^0.4.8",
+        "viem": "^2.37.3",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -559,6 +578,8 @@
 
     "@daydreamsai/mongodb": ["@daydreamsai/mongodb@workspace:packages/mongo"],
 
+    "@daydreamsai/peer-cash": ["@daydreamsai/peer-cash@workspace:packages/peer-cash"],
+
     "@daydreamsai/supabase": ["@daydreamsai/supabase@workspace:packages/supabase"],
 
     "@daydreamsai/telegram": ["@daydreamsai/telegram@workspace:packages/telegram"],
@@ -819,6 +840,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -869,6 +892,30 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rbiWYQWxwy+x7+KgNAoAGYIPB3xUclQlFVV3L5lwfsbp4PQPomJohHowlWgi3GRAEybM5+ZL9xny0YfpJOsthA=="],
 
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
@@ -894,6 +941,8 @@
     "@pythnetwork/hermes-client": ["@pythnetwork/hermes-client@2.0.0", "", { "dependencies": { "@zodios/core": "^10.9.6", "eventsource": "^3.0.5", "zod": "^3.23.8" } }, "sha512-8ZbCrO5NSlsu1zauIJjZv0sPR3qF9uzgCpBpAPSBGBjwKP0T3TdIRfuSzf9mpzrqf+b7QUqNVNLWZqgN7nlREw=="],
 
     "@pythnetwork/pyth-sui-js": ["@pythnetwork/pyth-sui-js@2.3.0", "", { "dependencies": { "@mysten/sui": "^1.3.0", "@pythnetwork/hermes-client": "2.0.0", "buffer": "^6.0.3" } }, "sha512-QOlbzhRBSYyVNofKr6vBJL/W+YNf/TZ4eqMBzjV18Rb1mG2ZdSA4IOuBj8n8ZVMvVU+CLWgGsHs5NkgcivHX6Q=="],
+
+    "@relayprotocol/relay-sdk": ["@relayprotocol/relay-sdk@6.1.3", "", { "dependencies": { "axios": "^1.6.5" }, "peerDependencies": { "viem": ">=2.26.0" } }, "sha512-JD6Cn6ejynKCiZo0NrMDC0bU7IJfJNWqCLr9NHCpV2s48T01zy+8uN+joBFVawsiRxakApgPkdE8FlQAeQxduA=="],
 
     "@roamhq/wrtc": ["@roamhq/wrtc@0.8.0", "", { "optionalDependencies": { "@roamhq/wrtc-darwin-arm64": "0.8.0", "@roamhq/wrtc-darwin-x64": "0.8.0", "@roamhq/wrtc-linux-arm64": "0.8.1", "@roamhq/wrtc-linux-x64": "0.8.1", "@roamhq/wrtc-win32-x64": "0.8.0", "domexception": "^4.0.0" } }, "sha512-C0V/nqc4/2xzORI5qa4mIeN/8UO3ywN1kInrJ9u6GljFx0D18JMUJEqe8yYHa61RrEeoWN3PKdW++k8TocSx/A=="],
 
@@ -1125,9 +1174,21 @@
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
+    "@zkp2p/cash": ["@zkp2p/cash@0.4.8", "", { "dependencies": { "@relayprotocol/relay-sdk": "^6.1.3", "@zkp2p/sdk": "0.12.0", "zod": "^3.25.76" }, "peerDependencies": { "react": ">=18", "viem": ">=2.37.3 <3" }, "optionalPeers": ["react"] }, "sha512-+JwFs2RFjzw9L0szLXuILJukE8acQXXE1WZlRJXxEQx9aFauJ/Rq8dqdx1AIs3xTZ8tG9eHRXkM1Dvx6daDaEg=="],
+
+    "@zkp2p/contracts-v2": ["@zkp2p/contracts-v2@0.4.0", "", { "dependencies": { "abitype": "^1.0.0" }, "peerDependencies": { "ethers": "^5.0.0 || ^6.0.0" } }, "sha512-wE4IfjRSUVfOiAULoh6eVUj5vExSlcMY6+VsRLOhGq+1q06uy/aS2lMYjzqoDAXibMpYPTVhsuy1MEB2jKGKqw=="],
+
+    "@zkp2p/indexer-schema": ["@zkp2p/indexer-schema@0.20.0", "", {}, "sha512-EQsmFfp61hI0zzILYoh8aPzf+CGeduoiAQQ+FD27oIQBj5piKFqNQCfzhI14A7lBWtS69gXqjPuJJTo/BOaO3w=="],
+
+    "@zkp2p/sdk": ["@zkp2p/sdk@0.12.0", "", { "dependencies": { "@zkp2p/contracts-v2": "0.4.0", "@zkp2p/indexer-schema": "0.20.0", "@zkp2p/zkp2p-attestation": "2.0.0", "ethers": "^6.0.0", "ox": "^0.11.1" }, "peerDependencies": { "react": ">=16.8.0", "viem": "^2.37.3" }, "optionalPeers": ["react"] }, "sha512-7boAYdUV+R3G+1hFOp7lQLxX9NUDVXtfW3RsgBt4ijhg3BqO9RBgpMfeWfqoE7kRUVDo/xNZL39bhBbXK6NmIA=="],
+
+    "@zkp2p/zkp2p-attestation": ["@zkp2p/zkp2p-attestation@2.0.0", "", { "dependencies": { "@peculiar/x509": "^1.14.0", "ethers": "^6.13.4" }, "bin": { "zkp2p-attestation-verify": "dist/cli/verify.js" } }, "sha512-m+HWDYTEW109xSqh0NWJFoWR0ZIoxJqQRguQltfr6RSkALBJFWv5WWDQrcPN0TiqTN2KdLI7BYQTDluZfjq2MA=="],
+
     "@zodios/core": ["@zodios/core@10.9.6", "", { "peerDependencies": { "axios": "^0.x || ^1.0.0", "zod": "^3.x" } }, "sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A=="],
 
     "abi-wan-kanabi": ["abi-wan-kanabi@2.2.4", "", { "dependencies": { "ansicolors": "^0.3.2", "cardinal": "^2.1.1", "fs-extra": "^10.0.0", "yargs": "^17.7.2" }, "bin": { "generate": "dist/generate.js" } }, "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg=="],
+
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -1160,6 +1221,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -1655,6 +1718,8 @@
 
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
     "istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
@@ -1941,6 +2006,8 @@
 
     "otpauth": ["otpauth@9.4.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-+iVvys36CFsyXEqfNftQm1II7SW23W1wx9RwNk0Cd97lbvorqAhBDksb/0bYry087QMxjiuBS0wokdoZ0iUeAw=="],
 
+    "ox": ["ox@0.14.33", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ=="],
+
     "oxc-resolver": ["oxc-resolver@11.12.0", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.12.0", "@oxc-resolver/binding-android-arm64": "11.12.0", "@oxc-resolver/binding-darwin-arm64": "11.12.0", "@oxc-resolver/binding-darwin-x64": "11.12.0", "@oxc-resolver/binding-freebsd-x64": "11.12.0", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.12.0", "@oxc-resolver/binding-linux-arm-musleabihf": "11.12.0", "@oxc-resolver/binding-linux-arm64-gnu": "11.12.0", "@oxc-resolver/binding-linux-arm64-musl": "11.12.0", "@oxc-resolver/binding-linux-ppc64-gnu": "11.12.0", "@oxc-resolver/binding-linux-riscv64-gnu": "11.12.0", "@oxc-resolver/binding-linux-riscv64-musl": "11.12.0", "@oxc-resolver/binding-linux-s390x-gnu": "11.12.0", "@oxc-resolver/binding-linux-x64-gnu": "11.12.0", "@oxc-resolver/binding-linux-x64-musl": "11.12.0", "@oxc-resolver/binding-wasm32-wasi": "11.12.0", "@oxc-resolver/binding-win32-arm64-msvc": "11.12.0", "@oxc-resolver/binding-win32-ia32-msvc": "11.12.0", "@oxc-resolver/binding-win32-x64-msvc": "11.12.0" } }, "sha512-zmS2q2txiB+hS2u0aiIwmvITIJN8c8ThlWoWB762Wx5nUw8WBlttp0rzt8nnuP1cGIq9YJ7sGxfsgokm+SQk5Q=="],
 
     "p-defer": ["p-defer@4.0.1", "", {}, "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="],
@@ -2017,6 +2084,10 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.2.0", "", {}, "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg=="],
+
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
     "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
@@ -2036,6 +2107,8 @@
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "redeyed": ["redeyed@2.1.1", "", { "dependencies": { "esprima": "~4.0.0" } }, "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
 
@@ -2251,6 +2324,8 @@
 
     "tsup": ["tsup@8.3.6", "", { "dependencies": { "bundle-require": "^5.0.0", "cac": "^6.7.14", "chokidar": "^4.0.1", "consola": "^3.2.3", "debug": "^4.3.7", "esbuild": "^0.24.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.24.0", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.1", "tinyglobby": "^0.2.9", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-XkVtlDV/58S9Ye0JxUUTcrQk4S+EqlOHKzg6Roa62rdjL1nGWNUstG0xgI4vanHdfIpjP448J8vlN0oK6XOJ5g=="],
 
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
@@ -2308,6 +2383,8 @@
     "valibot": ["valibot@0.36.0", "", {}, "sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "viem": ["viem@2.55.13", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Rt1NAsdtTdvJgqaCxsv2TuO55xv2d2dKEuRuzrg34xMGxvTSFOX0iIFvEfymPvh+fwN2tbgEU2JwN0YHOVM+Bg=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -2384,6 +2461,10 @@
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@daydreamsai/core/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@daydreamsai/peer-cash/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@discordjs/builders/discord-api-types": ["discord-api-types@0.38.31", "", {}, "sha512-kC94ANsk8ackj8ENTuO8joTNEL0KtymVhHy9dyEC/s4QAZ7GCx40dYEzQaadyo8w+oP0X8QydE/nzAWRylTGtQ=="],
 
@@ -2502,6 +2583,10 @@
     "@vitest/snapshot/@vitest/pretty-format": ["@vitest/pretty-format@3.0.5", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA=="],
 
     "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.0.5", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA=="],
+
+    "@zkp2p/cash/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@zkp2p/sdk/ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
 
     "@zodios/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -2653,6 +2738,10 @@
 
     "onnx-proto/protobufjs": ["protobufjs@6.11.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw=="],
 
+    "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -2707,6 +2796,12 @@
 
     "tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "viem/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "vite/esbuild": ["esbuild@0.25.11", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.11", "@esbuild/android-arm": "0.25.11", "@esbuild/android-arm64": "0.25.11", "@esbuild/android-x64": "0.25.11", "@esbuild/darwin-arm64": "0.25.11", "@esbuild/darwin-x64": "0.25.11", "@esbuild/freebsd-arm64": "0.25.11", "@esbuild/freebsd-x64": "0.25.11", "@esbuild/linux-arm": "0.25.11", "@esbuild/linux-arm64": "0.25.11", "@esbuild/linux-ia32": "0.25.11", "@esbuild/linux-loong64": "0.25.11", "@esbuild/linux-mips64el": "0.25.11", "@esbuild/linux-ppc64": "0.25.11", "@esbuild/linux-riscv64": "0.25.11", "@esbuild/linux-s390x": "0.25.11", "@esbuild/linux-x64": "0.25.11", "@esbuild/netbsd-arm64": "0.25.11", "@esbuild/netbsd-x64": "0.25.11", "@esbuild/openbsd-arm64": "0.25.11", "@esbuild/openbsd-x64": "0.25.11", "@esbuild/openharmony-arm64": "0.25.11", "@esbuild/sunos-x64": "0.25.11", "@esbuild/win32-arm64": "0.25.11", "@esbuild/win32-ia32": "0.25.11", "@esbuild/win32-x64": "0.25.11" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -2722,6 +2817,10 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@daydreamsai/core/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@daydreamsai/peer-cash/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@discordjs/ws/@types/ws/@types/node": ["@types/node@22.18.12", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog=="],
 
@@ -2750,6 +2849,10 @@
     "@supabase/realtime-js/@types/ws/@types/node": ["@types/node@22.18.12", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog=="],
 
     "@types/request/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@zkp2p/sdk/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@zkp2p/sdk/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
@@ -2874,6 +2977,10 @@
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@daydreamsai/core/@types/bun/bun-types/@types/node": ["@types/node@22.18.12", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog=="],
+
+    "@daydreamsai/peer-cash/@types/bun/bun-types/@types/node": ["@types/node@22.18.12", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog=="],
 
     "@jest/reporters/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/packages/peer-cash/README.md
+++ b/packages/peer-cash/README.md
@@ -1,0 +1,122 @@
+# @daydreamsai/peer-cash
+
+[Peer Cash](https://peer.xyz/cash-sdk) extension for Daydreams agents: cash out
+Base USDC to fiat in payment apps (Venmo, Revolut, Wise, Zelle, and more)
+through the Peer P2P protocol.
+
+The extension wraps the
+[`@zkp2p/cash`](https://www.npmjs.com/package/@zkp2p/cash) SDK. It is offramp
+only and non-custodial: the agent wallet deposits USDC into the Peer escrow
+contract, a buyer pays the payee fiat and proves the payment, and the protocol
+releases the USDC. There is no API key, no hosted widget, and no custody by any
+provider. Pricing is the live Chainlink oracle rate at fill time with zero
+spread.
+
+## Installation
+
+```bash
+pnpm add @daydreamsai/peer-cash
+```
+
+## Quick start
+
+```ts
+import { createDreams } from "@daydreamsai/core";
+import { createPeerCashExtension } from "@daydreamsai/peer-cash";
+
+const agent = createDreams({
+  model,
+  extensions: [
+    createPeerCashExtension({
+      environment: "production",
+      referralCode: "ABC123", // optional, see "Earn the integration share"
+    }),
+  ],
+});
+```
+
+Set the agent wallet through the environment:
+
+```bash
+export PEER_CASH_PRIVATE_KEY=0x... # wallet holding Base USDC
+```
+
+Without a wallet the read actions still work; transaction-signing actions return
+a `WALLET_NOT_CONFIGURED` error result instead of throwing.
+
+## Configuration
+
+`createPeerCashExtension(config)` validates its configuration when called and
+throws on invalid values.
+
+| Option         | Env fallback            | Default        | Description                                                          |
+| -------------- | ----------------------- | -------------- | -------------------------------------------------------------------- |
+| `environment`  | `PEER_CASH_ENVIRONMENT` | `"production"` | `production`, `preproduction`, or `staging`                          |
+| `referralCode` |                         |                | Six-character Peer referral code; earns the 50 bps integration share |
+| `referrer`     |                         |                | Analytics-only ERC-8021 attribution code(s); carries no payout       |
+| `privateKey`   | `PEER_CASH_PRIVATE_KEY` |                | Agent wallet key for signing Base transactions                       |
+| `rpcUrl`       | `PEER_CASH_RPC_URL`     | public Base    | Base RPC endpoint                                                    |
+| `client`       |                         |                | Preconstructed `CashClient`, used by tests and advanced hosts        |
+
+## Actions
+
+| Action                   | Signs transactions | Description                                                                     |
+| ------------------------ | ------------------ | ------------------------------------------------------------------------------- |
+| `peer-cash.capabilities` | No                 | Supported platforms, currencies, payee format hints, and amount bounds          |
+| `peer-cash.fillStats`    | No                 | 30-day fill counts and median first-fill time per `platform:currency` pair      |
+| `peer-cash.estimate`     | No                 | Oracle rate, fiat receive amount, and historical ETA for a prospective cash-out |
+| `peer-cash.cashout`      | Yes                | Create a cash-out order: platform, currency, payee handle, USDC amount          |
+| `peer-cash.order`        | No                 | Live order state by deposit id, with a plain-language explanation               |
+| `peer-cash.orders`       | No                 | List orders for a wallet (defaults to the agent wallet)                         |
+| `peer-cash.withdraw`     | Yes                | The one unwind verb: partial with an amount, full close without                 |
+| `peer-cash.topUp`        | Yes                | Add USDC to a live order at the same payee and market rate                      |
+
+Amounts cross the action boundary as decimal USDC strings (`"25.50"`); results
+are returned through the SDK's JSON codecs, so every action result is
+serializable and safe to persist in working memory.
+
+## Safety notes
+
+- Non-custodial. Funds sit in the Peer escrow contract. Only the agent wallet
+  can withdraw an unmatched deposit.
+- The agent's wallet signs. `cashout`, `withdraw`, and `topUp` sign and submit
+  Base transactions from the configured wallet. All three share one task queue
+  so the wallet never signs concurrently, and none of them auto-retry.
+- An estimate is not a locked quote. `peer-cash.estimate` reports the current
+  oracle read; the binding rate resolves at the Chainlink oracle when a buyer
+  fills, always with zero spread.
+- Errors are data. Failures return
+  `{ error: { code, message, retryable, remediation } }` so the agent can decide
+  what to do next instead of crashing the run. Transaction-unknown states
+  include recovery evidence; inspect before retrying anything that moves funds.
+- The payee must be a real account on the payout platform. New Wise and PayPal
+  payees require an identity attestation minted by Peer's TEE browser extension;
+  such cash-outs fail with `PAYEE_VERIFICATION_REQUIRED` before any funds move.
+
+## Earn the integration share
+
+Pass the six-character referral code shown in your Peer mobile or web app:
+
+```ts
+createPeerCashExtension({ referralCode: "ABC123" });
+```
+
+Deposits created by the extension then carry the `peer-ref-ABC123` ERC-8021
+marker. When that liquidity fills, the protocol pays the code owner a 50 bps
+integration share, capped by the configured Peer service fee. The code-to-wallet
+mapping is permanent. No registration, API key, or separate receiving address is
+needed.
+
+The `referrer` option is separate: it stamps analytics-only attribution codes
+and never pays out.
+
+## Links
+
+- npm: <https://www.npmjs.com/package/@zkp2p/cash>
+- Peer Cash: <https://peer.xyz/cash-sdk>
+- SDK documentation: <https://docs.peer.xyz/developer/peer-cash>
+
+## Support
+
+Questions and integration help: the Peer Builders Club on Telegram at
+<https://t.me/zk_p2p/167174>.

--- a/packages/peer-cash/package.json
+++ b/packages/peer-cash/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@daydreamsai/peer-cash",
+  "version": "0.3.22",
+  "description": "Peer Cash extension: cash out Base USDC to fiat payment apps at the live oracle rate",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.js"
+    }
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "tsup": "catalog:",
+    "vitest": "catalog:"
+  },
+  "scripts": {
+    "test": "vitest",
+    "build": "tsup --dts-resolve",
+    "prepublishOnly": "pnpm run build"
+  },
+  "peerDependencies": {
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@daydreamsai/core": "workspace:*",
+    "@zkp2p/cash": "^0.4.8",
+    "viem": "^2.37.3",
+    "zod": "catalog:"
+  }
+}

--- a/packages/peer-cash/src/__tests__/peer-cash.test.ts
+++ b/packages/peer-cash/src/__tests__/peer-cash.test.ts
@@ -1,0 +1,583 @@
+import { describe, expect, it } from "vitest";
+import {
+  capabilitiesFromJson,
+  cashoutResultFromJson,
+  errors,
+  estimateFromJson,
+  fillStatsFromJson,
+  orderFromJson,
+  topUpResultFromJson,
+  withdrawResultFromJson,
+} from "@zkp2p/cash";
+import type {
+  CashClient,
+  CashoutInput,
+  CashoutOptions,
+  EstimateInput,
+  EstimateOptions,
+  OrdersOptions,
+  SignerOptions,
+  WithdrawOptions,
+} from "@zkp2p/cash";
+import { createPeerCashExtension } from "../peer-cash";
+
+/** Well-known local development key (anvil account 0). Never funded. */
+const TEST_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const TEST_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+const USDC_TOKEN = {
+  address: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  symbol: "USDC" as const,
+  decimals: 6,
+};
+
+const CAPABILITIES_JSON = {
+  chainId: 8453,
+  token: USDC_TOKEN,
+  environment: "production" as const,
+  destination: { chainId: 8453, token: USDC_TOKEN },
+  source: { default: { chainId: 8453, token: USDC_TOKEN } },
+  platforms: [
+    {
+      platform: "venmo",
+      currencies: ["USD"],
+      payeeHint: "Venmo username, e.g. @user",
+      requiresIdentityAttestation: false,
+      // Deprecated wire-compat field; always false.
+      requiresAtomicAccessPolicy: false,
+    },
+    {
+      platform: "revolut",
+      currencies: ["EUR", "GBP", "USD"],
+      payeeHint: "Revtag",
+      requiresIdentityAttestation: false,
+      requiresAtomicAccessPolicy: false,
+    },
+  ],
+  currencies: ["USD", "EUR", "GBP"],
+  amount: { min: "10000", recommendedMin: "10000000", max: null },
+  pricing: { kind: "oracle-market-rate" as const, spreadBps: 0 as const },
+};
+
+const FILL_STATS_JSON = {
+  "venmo:USD": { fills: 42, medianFillSeconds: 900 },
+  "revolut:EUR+GBP+USD": { fills: 7 },
+};
+
+const ESTIMATE_JSON = {
+  kind: "oracle-estimate" as const,
+  currency: "EUR",
+  amount: "1500000",
+  rate: 0.92,
+  receiveAmount: 1.38,
+  asOf: 1723500000,
+};
+
+const ORDER_JSON = {
+  depositId: "0x71e18f1b6a1c1a4dfa5c1728f5b70cf4a4d5c111_12",
+  state: "awaiting-buyer" as const,
+  fills: [],
+  totalAmount: "25500000",
+  filledAmount: "0",
+  pendingAmount: "0",
+  returnedAmount: "0",
+  nextActions: ["wait", "withdraw"] as const,
+  isInFlight: true,
+};
+
+const CASHOUT_RESULT_JSON = {
+  depositId: ORDER_JSON.depositId,
+  txHash: `0x${"ab".repeat(32)}`,
+  escrowAddress: "0x71e18f1b6a1c1a4dfa5c1728f5b70cf4a4d5c111",
+  onchainDepositId: "12",
+  order: ORDER_JSON,
+};
+
+const WITHDRAW_RESULT_JSON = {
+  depositId: ORDER_JSON.depositId,
+  withdrawTxHash: `0x${"cd".repeat(32)}`,
+};
+
+const TOP_UP_RESULT_JSON = {
+  depositId: ORDER_JSON.depositId,
+  txHash: `0x${"ef".repeat(32)}`,
+};
+
+/** Builds a CashClient test double; every unexpected call throws. */
+function mockClient(overrides: Partial<CashClient>): CashClient {
+  return new Proxy(overrides, {
+    get(target, property: string) {
+      if (property in target) {
+        return target[property as keyof typeof target];
+      }
+      return () => {
+        throw new Error(`unexpected CashClient call: ${property}`);
+      };
+    },
+  }) as CashClient;
+}
+
+type PeerCashExtension = ReturnType<typeof createPeerCashExtension>;
+
+function getAction(ext: PeerCashExtension, name: string) {
+  const found = ext.actions?.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`missing action: ${name}`);
+  return found;
+}
+
+async function callAction(
+  ext: PeerCashExtension,
+  name: string,
+  args?: Record<string, unknown>
+) {
+  const handler = getAction(ext, name).handler as (
+    ...handlerArgs: unknown[]
+  ) => unknown;
+  return await handler(args, {}, {});
+}
+
+describe("createPeerCashExtension", () => {
+  it("exposes the peer-cash extension surface", () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    expect(ext.name).toBe("peer-cash");
+    expect(ext.actions?.map((action) => action.name)).toEqual([
+      "peer-cash.capabilities",
+      "peer-cash.fillStats",
+      "peer-cash.estimate",
+      "peer-cash.cashout",
+      "peer-cash.order",
+      "peer-cash.orders",
+      "peer-cash.withdraw",
+      "peer-cash.topUp",
+    ]);
+  });
+
+  it("serializes every transaction-signing action on one queue", () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    for (const name of [
+      "peer-cash.cashout",
+      "peer-cash.withdraw",
+      "peer-cash.topUp",
+    ]) {
+      expect(getAction(ext, name).queueKey).toBe("peer-cash:transactions");
+    }
+    for (const name of [
+      "peer-cash.capabilities",
+      "peer-cash.fillStats",
+      "peer-cash.estimate",
+      "peer-cash.order",
+      "peer-cash.orders",
+    ]) {
+      expect(getAction(ext, name).queueKey).toBeUndefined();
+    }
+  });
+
+  it("rejects an unknown environment", () => {
+    expect(() =>
+      createPeerCashExtension({
+        environment: "testnet" as never,
+        client: mockClient({}),
+      })
+    ).toThrow(/invalid environment "testnet"/);
+  });
+
+  it("rejects a malformed referral code", () => {
+    expect(() =>
+      createPeerCashExtension({
+        referralCode: "not-a-code",
+        client: mockClient({}),
+      })
+    ).toThrow(/invalid referralCode/);
+  });
+
+  it("accepts a six-character referral code", () => {
+    expect(() =>
+      createPeerCashExtension({
+        referralCode: "ABC123",
+        client: mockClient({}),
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects a malformed private key", () => {
+    expect(() =>
+      createPeerCashExtension({
+        privateKey: "0x1234" as never,
+        client: mockClient({}),
+      })
+    ).toThrow(/invalid privateKey/);
+  });
+
+  it("reads the agent wallet from PEER_CASH_PRIVATE_KEY", async () => {
+    process.env.PEER_CASH_PRIVATE_KEY = TEST_PRIVATE_KEY;
+    try {
+      let seenOwner: string | undefined;
+      const ext = createPeerCashExtension({
+        client: mockClient({
+          orders: async (owner) => {
+            seenOwner = owner;
+            return [orderFromJson(ORDER_JSON)];
+          },
+        }),
+      });
+
+      await callAction(ext, "peer-cash.orders", {});
+      expect(seenOwner).toBe(TEST_ADDRESS);
+    } finally {
+      delete process.env.PEER_CASH_PRIVATE_KEY;
+    }
+  });
+});
+
+describe("peer-cash.capabilities", () => {
+  it("returns the serialized capability catalog", async () => {
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        capabilities: (() =>
+          capabilitiesFromJson(
+            CAPABILITIES_JSON
+          )) as CashClient["capabilities"],
+      }),
+    });
+
+    const result = await callAction(ext, "peer-cash.capabilities");
+    expect(result).toEqual({ capabilities: CAPABILITIES_JSON });
+  });
+});
+
+describe("peer-cash.fillStats", () => {
+  it("returns serialized 30-day pair stats", async () => {
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        fillStats: async () => fillStatsFromJson(FILL_STATS_JSON),
+      }),
+    });
+
+    const result = await callAction(ext, "peer-cash.fillStats");
+    expect(result).toEqual({ fillStats: FILL_STATS_JSON });
+  });
+});
+
+describe("peer-cash.estimate", () => {
+  it("converts the amount, uppercases the currency, and serializes", async () => {
+    let seenInput: EstimateInput | undefined;
+    let seenOptions: EstimateOptions | undefined;
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        estimate: async (input, options) => {
+          seenInput = input;
+          seenOptions = options;
+          return estimateFromJson(ESTIMATE_JSON);
+        },
+      }),
+    });
+
+    const result = await callAction(ext, "peer-cash.estimate", {
+      amountUsdc: "1.50",
+      currency: "eur",
+      platform: "revolut",
+    });
+
+    expect(seenInput?.amount).toBe(1_500_000n);
+    expect(seenInput?.currency).toBe("EUR");
+    expect(seenInput?.platform).toBe("revolut");
+    expect(seenOptions).toEqual({ includeEta: true });
+    expect(result).toEqual({ estimate: ESTIMATE_JSON });
+  });
+
+  it("passes includeEta false through", async () => {
+    let seenOptions: EstimateOptions | undefined;
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        estimate: async (_input, options) => {
+          seenOptions = options;
+          return estimateFromJson(ESTIMATE_JSON);
+        },
+      }),
+    });
+
+    await callAction(ext, "peer-cash.estimate", {
+      amountUsdc: "1000",
+      currency: "USD",
+      includeEta: false,
+    });
+    expect(seenOptions).toEqual({ includeEta: false });
+  });
+
+  it("maps a CashError to an agent-readable error result", async () => {
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        estimate: async () => {
+          throw errors.oracleUnsupportedCurrency("XYZ");
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.estimate", {
+      amountUsdc: "10",
+      currency: "XYZ",
+    })) as { error: { code: string; retryable: boolean; remediation: string } };
+
+    expect(result.error.code).toBe("ORACLE_UNSUPPORTED_CURRENCY");
+    expect(result.error.retryable).toBe(false);
+    expect(result.error.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("maps an unexpected error without leaking a throw", async () => {
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        estimate: async () => {
+          throw new Error("socket hang up");
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.estimate", {
+      amountUsdc: "10",
+      currency: "USD",
+    })) as { error: { code: string; message: string } };
+
+    expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    expect(result.error.message).toBe("socket hang up");
+  });
+});
+
+describe("peer-cash.cashout", () => {
+  it("returns WALLET_NOT_CONFIGURED without a private key", async () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    const result = (await callAction(ext, "peer-cash.cashout", {
+      amountUsdc: "25.50",
+      platform: "venmo",
+      currency: "USD",
+      payee: "@alice",
+    })) as { error: { code: string; remediation: string } };
+
+    expect(result.error.code).toBe("WALLET_NOT_CONFIGURED");
+    expect(result.error.remediation).toContain("PEER_CASH_PRIVATE_KEY");
+  });
+
+  it("signs with the configured wallet and serializes the result", async () => {
+    let seenInput: CashoutInput | undefined;
+    let seenOptions: CashoutOptions | undefined;
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        cashout: async (input, options) => {
+          seenInput = input;
+          seenOptions = options;
+          return cashoutResultFromJson(CASHOUT_RESULT_JSON);
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.cashout", {
+      amountUsdc: "25.50",
+      platform: "venmo",
+      currency: "usd",
+      payee: "@alice",
+    })) as { result: typeof CASHOUT_RESULT_JSON; explain: string };
+
+    expect(seenInput?.amount).toBe(25_500_000n);
+    expect(seenInput?.receive).toEqual({
+      platform: "venmo",
+      currency: "USD",
+      payee: "@alice",
+    });
+    expect(seenOptions?.signer.account?.address).toBe(TEST_ADDRESS);
+    expect(result.result).toEqual(CASHOUT_RESULT_JSON);
+    expect(result.explain.length).toBeGreaterThan(0);
+  });
+
+  it("maps a CashError from the cashout path", async () => {
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        cashout: async () => {
+          throw errors.unsupportedPlatform("carrier-pigeon");
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.cashout", {
+      amountUsdc: "25.50",
+      platform: "carrier-pigeon",
+      currency: "USD",
+      payee: "@alice",
+    })) as { error: { code: string } };
+
+    expect(result.error.code).toBe("UNSUPPORTED_PLATFORM");
+  });
+});
+
+describe("peer-cash.order", () => {
+  it("returns live order state with an explanation", async () => {
+    let seenDepositId: string | undefined;
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        order: async (depositId) => {
+          seenDepositId = depositId;
+          return orderFromJson(ORDER_JSON);
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.order", {
+      depositId: ORDER_JSON.depositId,
+    })) as { order: { state: string; explain: string } };
+
+    expect(seenDepositId).toBe(ORDER_JSON.depositId);
+    expect(result.order.state).toBe("awaiting-buyer");
+    expect(result.order.explain.length).toBeGreaterThan(0);
+  });
+});
+
+describe("peer-cash.orders", () => {
+  it("defaults to the agent wallet and passes filters through", async () => {
+    let seenOwner: string | undefined;
+    let seenOptions: OrdersOptions | undefined;
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        orders: async (owner, options) => {
+          seenOwner = owner;
+          seenOptions = options;
+          return [orderFromJson(ORDER_JSON)];
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.orders", {
+      inFlight: true,
+      limit: 25,
+    })) as { owner: string; count: number; orders: { explain: string }[] };
+
+    expect(seenOwner).toBe(TEST_ADDRESS);
+    expect(seenOptions).toEqual({ inFlight: true, limit: 25 });
+    expect(result.owner).toBe(TEST_ADDRESS);
+    expect(result.count).toBe(1);
+    expect(result.orders[0]?.explain.length).toBeGreaterThan(0);
+  });
+
+  it("accepts an explicit owner without a configured wallet", async () => {
+    const owner = "0x71e18f1b6a1c1a4dfa5c1728f5b70cf4a4d5c111";
+    let seenOwner: string | undefined;
+    const ext = createPeerCashExtension({
+      client: mockClient({
+        orders: async (target) => {
+          seenOwner = target;
+          return [];
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.orders", {
+      owner,
+    })) as { count: number };
+
+    expect(seenOwner).toBe(owner);
+    expect(result.count).toBe(0);
+  });
+
+  it("returns WALLET_NOT_CONFIGURED with no wallet and no owner", async () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    const result = (await callAction(ext, "peer-cash.orders", {})) as {
+      error: { code: string };
+    };
+    expect(result.error.code).toBe("WALLET_NOT_CONFIGURED");
+  });
+});
+
+describe("peer-cash.withdraw", () => {
+  it("closes an order fully when no amount is given", async () => {
+    let seenOptions: WithdrawOptions | undefined;
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        withdraw: async (_depositId, options) => {
+          seenOptions = options;
+          return withdrawResultFromJson(WITHDRAW_RESULT_JSON);
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.withdraw", {
+      depositId: ORDER_JSON.depositId,
+    })) as { result: typeof WITHDRAW_RESULT_JSON };
+
+    expect(seenOptions?.amount).toBeUndefined();
+    expect(seenOptions?.signer.account?.address).toBe(TEST_ADDRESS);
+    expect(result.result).toEqual(WITHDRAW_RESULT_JSON);
+  });
+
+  it("withdraws a partial amount in USDC base units", async () => {
+    let seenOptions: WithdrawOptions | undefined;
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        withdraw: async (_depositId, options) => {
+          seenOptions = options;
+          return withdrawResultFromJson(WITHDRAW_RESULT_JSON);
+        },
+      }),
+    });
+
+    await callAction(ext, "peer-cash.withdraw", {
+      depositId: ORDER_JSON.depositId,
+      amountUsdc: "5",
+    });
+    expect(seenOptions?.amount).toBe(5_000_000n);
+  });
+
+  it("returns WALLET_NOT_CONFIGURED without a private key", async () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    const result = (await callAction(ext, "peer-cash.withdraw", {
+      depositId: ORDER_JSON.depositId,
+    })) as { error: { code: string } };
+    expect(result.error.code).toBe("WALLET_NOT_CONFIGURED");
+  });
+});
+
+describe("peer-cash.topUp", () => {
+  it("adds USDC to a live order", async () => {
+    let seenDepositId: string | undefined;
+    let seenAmount: bigint | undefined;
+    let seenOptions: SignerOptions | undefined;
+    const ext = createPeerCashExtension({
+      privateKey: TEST_PRIVATE_KEY,
+      client: mockClient({
+        topUp: async (depositId, amount, options) => {
+          seenDepositId = depositId;
+          seenAmount = amount;
+          seenOptions = options;
+          return topUpResultFromJson(TOP_UP_RESULT_JSON);
+        },
+      }),
+    });
+
+    const result = (await callAction(ext, "peer-cash.topUp", {
+      depositId: ORDER_JSON.depositId,
+      amountUsdc: "10",
+    })) as { result: typeof TOP_UP_RESULT_JSON };
+
+    expect(seenDepositId).toBe(ORDER_JSON.depositId);
+    expect(seenAmount).toBe(10_000_000n);
+    expect(seenOptions?.signer.account?.address).toBe(TEST_ADDRESS);
+    expect(result.result).toEqual(TOP_UP_RESULT_JSON);
+  });
+
+  it("returns WALLET_NOT_CONFIGURED without a private key", async () => {
+    const ext = createPeerCashExtension({ client: mockClient({}) });
+
+    const result = (await callAction(ext, "peer-cash.topUp", {
+      depositId: ORDER_JSON.depositId,
+      amountUsdc: "10",
+    })) as { error: { code: string } };
+    expect(result.error.code).toBe("WALLET_NOT_CONFIGURED");
+  });
+});

--- a/packages/peer-cash/src/index.ts
+++ b/packages/peer-cash/src/index.ts
@@ -1,0 +1,2 @@
+export { createPeerCashExtension } from "./peer-cash";
+export type { PeerCashConfig } from "./peer-cash";

--- a/packages/peer-cash/src/peer-cash.ts
+++ b/packages/peer-cash/src/peer-cash.ts
@@ -1,0 +1,465 @@
+import * as z from "zod";
+import { action, extension, Logger } from "@daydreamsai/core";
+import {
+  capabilitiesToJson,
+  cashErrorToJson,
+  cashoutResultToJson,
+  createCashClient,
+  estimateToJson,
+  fillStatsToJson,
+  isCashError,
+  orderToJson,
+  topUpResultToJson,
+  usdc,
+  withdrawResultToJson,
+} from "@zkp2p/cash";
+import type {
+  CashClient,
+  CashOrder,
+  CurrencyType,
+  RuntimeEnv,
+} from "@zkp2p/cash";
+import { createWalletClient, http } from "viem";
+import type { WalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
+const ENVIRONMENTS = ["production", "preproduction", "staging"] as const;
+const REFERRAL_CODE_PATTERN = /^[A-Za-z0-9]{6}$/;
+const PRIVATE_KEY_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * All Peer Cash transactions run through one task queue so the agent never
+ * signs two Base transactions concurrently from the same wallet.
+ */
+const TRANSACTION_QUEUE = "peer-cash:transactions";
+
+export interface PeerCashConfig {
+  /**
+   * Peer protocol environment. Defaults to `PEER_CASH_ENVIRONMENT` or
+   * `"production"`.
+   */
+  environment?: RuntimeEnv;
+  /**
+   * Your six-character referral code from the Peer mobile or web app.
+   * Deposits created by this extension carry the `peer-ref-XXXXXX` ERC-8021
+   * marker; when they fill, the protocol pays the code owner a 50 bps
+   * integration share. The code-to-wallet mapping is permanent.
+   */
+  referralCode?: string;
+  /**
+   * Analytics-only ERC-8021 attribution code(s), e.g. `"acme-app"`. Carries
+   * no payout; use `referralCode` for the integration share.
+   */
+  referrer?: string | string[];
+  /**
+   * Private key of the agent wallet that holds Base USDC and signs cash-out,
+   * withdraw, and top-up transactions. Defaults to `PEER_CASH_PRIVATE_KEY`.
+   * When absent, read actions still work and mutating actions return a
+   * `WALLET_NOT_CONFIGURED` error.
+   */
+  privateKey?: `0x${string}`;
+  /**
+   * Base RPC URL. Defaults to `PEER_CASH_RPC_URL` or the public Base RPC.
+   */
+  rpcUrl?: string;
+  /** Preconstructed client, used by tests and advanced hosts. */
+  client?: CashClient;
+}
+
+interface PeerCashActionError {
+  code: string;
+  message: string;
+  retryable: boolean;
+  remediation?: string;
+  recovery?: unknown;
+}
+
+interface ResolvedPeerCashConfig {
+  environment: RuntimeEnv;
+  referralCode?: string;
+  referrer?: string | string[];
+  rpcUrl?: string;
+  wallet?: WalletClient;
+  walletAddress?: string;
+}
+
+function resolveConfig(config: PeerCashConfig): ResolvedPeerCashConfig {
+  const environment = (config.environment ??
+    process.env.PEER_CASH_ENVIRONMENT ??
+    "production") as RuntimeEnv;
+  if (!ENVIRONMENTS.includes(environment)) {
+    throw new Error(
+      `@daydreamsai/peer-cash: invalid environment "${environment}". ` +
+        `Expected one of: ${ENVIRONMENTS.join(", ")}.`
+    );
+  }
+
+  if (
+    config.referralCode !== undefined &&
+    !REFERRAL_CODE_PATTERN.test(config.referralCode)
+  ) {
+    throw new Error(
+      `@daydreamsai/peer-cash: invalid referralCode "${config.referralCode}". ` +
+        `Expected the six-character code shown in your Peer app.`
+    );
+  }
+
+  const privateKey =
+    config.privateKey ??
+    (process.env.PEER_CASH_PRIVATE_KEY as `0x${string}` | undefined);
+  if (privateKey !== undefined && !PRIVATE_KEY_PATTERN.test(privateKey)) {
+    throw new Error(
+      "@daydreamsai/peer-cash: invalid privateKey. Expected a 0x-prefixed " +
+        "32-byte hex string."
+    );
+  }
+
+  const rpcUrl = config.rpcUrl ?? process.env.PEER_CASH_RPC_URL;
+
+  let wallet: WalletClient | undefined;
+  let walletAddress: string | undefined;
+  if (privateKey) {
+    const account = privateKeyToAccount(privateKey);
+    wallet = createWalletClient({
+      account,
+      chain: base,
+      transport: http(rpcUrl),
+    });
+    walletAddress = account.address;
+  }
+
+  return {
+    environment,
+    referralCode: config.referralCode,
+    referrer: config.referrer,
+    rpcUrl,
+    wallet,
+    walletAddress,
+  };
+}
+
+function toActionError(error: unknown): { error: PeerCashActionError } {
+  if (isCashError(error)) {
+    return { error: cashErrorToJson(error) };
+  }
+  return {
+    error: {
+      code: "UNEXPECTED_ERROR",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    },
+  };
+}
+
+function walletNotConfigured(): { error: PeerCashActionError } {
+  return {
+    error: {
+      code: "WALLET_NOT_CONFIGURED",
+      message:
+        "No agent wallet is configured, so signing transactions is not possible.",
+      retryable: false,
+      remediation:
+        "Configure the extension with privateKey or set PEER_CASH_PRIVATE_KEY, " +
+        "then restart the agent. Read actions work without a wallet.",
+    },
+  };
+}
+
+function serializeOrder(order: CashOrder) {
+  return { ...orderToJson(order), explain: order.explain() };
+}
+
+const usdcAmountSchema = z
+  .string()
+  .regex(/^\d+(\.\d{1,6})?$/)
+  .describe(
+    "USDC amount as a decimal string with up to 6 decimals, e.g. '25.50'"
+  );
+
+const currencySchema = z
+  .string()
+  .regex(/^[A-Za-z]{3}$/)
+  .describe("ISO 4217 fiat currency code, e.g. 'USD', 'EUR', 'GBP'");
+
+const depositIdSchema = z
+  .string()
+  .min(1)
+  .describe(
+    "Composite deposit id returned by peer-cash.cashout, e.g. '0xabc..._12'"
+  );
+
+/**
+ * Creates an extension that exposes Peer Cash to the agent: cash out Base
+ * USDC to fiat in payment apps (Venmo, Revolut, Wise, Zelle, and more) via
+ * the Peer P2P protocol.
+ *
+ * The extension is non-custodial. Funds move from the agent wallet into the
+ * Peer escrow contract, only that wallet can withdraw an unmatched deposit,
+ * and there are no API keys. Pricing is the live Chainlink oracle rate at
+ * fill time with zero spread; estimates are approximate, never locked.
+ *
+ * @param config Environment, referral attribution, and agent wallet settings
+ * @returns An extension for the agent's extensions list
+ */
+export function createPeerCashExtension(config: PeerCashConfig = {}) {
+  const resolved = resolveConfig(config);
+
+  const client =
+    config.client ??
+    createCashClient({
+      environment: resolved.environment,
+      rpcUrl: resolved.rpcUrl,
+      referralCode: resolved.referralCode,
+      referrer: resolved.referrer,
+    });
+
+  return extension({
+    name: "peer-cash",
+
+    install(agent) {
+      const logger = agent.container.resolve<Logger>("logger");
+      logger.info("peer-cash:extension", "Peer Cash extension installed", {
+        environment: resolved.environment,
+        wallet: resolved.walletAddress ?? "not configured (read-only)",
+        referralCode: resolved.referralCode !== undefined,
+      });
+    },
+
+    actions: [
+      action({
+        name: "peer-cash.capabilities",
+        description:
+          "List what Peer Cash can do right now: supported payout platforms, " +
+          "their fiat currencies, payee handle format hints, and min/max " +
+          "cash-out bounds. Call this before the first cashout.",
+        handler() {
+          try {
+            return { capabilities: capabilitiesToJson(client.capabilities()) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.fillStats",
+        description:
+          "Raw 30-day demand evidence per 'platform:currency' pair: completed " +
+          "fill counts and median time to first fill. Use it to pick a " +
+          "corridor. A reasonable gate is fills >= 10 and median <= 48h; if " +
+          "stats are unavailable or the gate would empty the catalog, fall " +
+          "back to the full capabilities list.",
+        async handler() {
+          try {
+            return { fillStats: fillStatsToJson(await client.fillStats()) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.estimate",
+        description:
+          "Estimate a cash-out at the current Chainlink oracle rate: rate, " +
+          "fiat receive amount, and a historical fill-time ETA. This is an " +
+          "approximation for planning. It is NOT a locked quote; the binding " +
+          "rate resolves at the oracle when a buyer fills, always with zero " +
+          "spread. No side effects.",
+        schema: {
+          amountUsdc: usdcAmountSchema,
+          currency: currencySchema,
+          platform: z
+            .string()
+            .optional()
+            .describe(
+              "Optional payout platform id for platform-specific ETA sampling"
+            ),
+          includeEta: z
+            .boolean()
+            .optional()
+            .describe("Set false to skip the historical ETA lookup"),
+        },
+        async handler({ amountUsdc, currency, platform, includeEta }) {
+          try {
+            const estimate = await client.estimate(
+              {
+                amount: usdc(amountUsdc),
+                currency: currency.toUpperCase() as CurrencyType,
+                platform,
+              },
+              { includeEta: includeEta !== false }
+            );
+            return { estimate: estimateToJson(estimate) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.cashout",
+        description:
+          "Cash out USDC from the agent wallet to fiat in a payment app. " +
+          "This SIGNS AND SUBMITS Base transactions: USDC moves from the " +
+          "agent wallet into the Peer escrow contract as a deposit priced at " +
+          "the live oracle rate, a buyer pays the payee fiat and proves it, " +
+          "and the protocol releases the USDC to the buyer. Only the agent " +
+          "wallet can withdraw an unmatched deposit. The payee must be a " +
+          "real account on the platform. Returns a depositId; track it with " +
+          "peer-cash.order and unwind it with peer-cash.withdraw.",
+        schema: {
+          amountUsdc: usdcAmountSchema,
+          platform: z
+            .string()
+            .describe("Payout platform id from capabilities, e.g. 'venmo'"),
+          currency: currencySchema,
+          payee: z
+            .string()
+            .min(1)
+            .describe(
+              "Payee handle on the platform, e.g. '@user' for Venmo. Follow " +
+                "the payeeHint from capabilities."
+            ),
+        },
+        queueKey: TRANSACTION_QUEUE,
+        async handler({ amountUsdc, platform, currency, payee }) {
+          const signer = resolved.wallet;
+          if (!signer) return walletNotConfigured();
+          try {
+            const result = await client.cashout(
+              {
+                amount: usdc(amountUsdc),
+                receive: {
+                  platform,
+                  currency: currency.toUpperCase() as CurrencyType,
+                  payee,
+                },
+              },
+              { signer }
+            );
+            return {
+              result: cashoutResultToJson(result),
+              explain: result.order.explain(),
+            };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.order",
+        description:
+          "Fetch the live state of a cash-out order by depositId: state " +
+          "(awaiting-buyer, matched, delivering, delivered, returned), fill " +
+          "receipts, amounts, a plain-language explanation, and nextActions " +
+          "('wait' or 'withdraw'). Orders are resumable from the depositId " +
+          "alone.",
+        schema: { depositId: depositIdSchema },
+        async handler({ depositId }) {
+          try {
+            return { order: serializeOrder(await client.order(depositId)) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.orders",
+        description:
+          "List cash-out orders for a wallet address. Defaults to the agent " +
+          "wallet. Set inFlight true to only list orders that still need " +
+          "attention.",
+        schema: {
+          owner: z
+            .string()
+            .regex(ADDRESS_PATTERN)
+            .optional()
+            .describe("Wallet address; defaults to the agent wallet"),
+          inFlight: z
+            .boolean()
+            .optional()
+            .describe("Only orders still awaiting a buyer or a fill"),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Max deposits to scan (default 100)"),
+        },
+        async handler({ owner, inFlight, limit }) {
+          const target = owner ?? resolved.walletAddress;
+          if (!target) return walletNotConfigured();
+          try {
+            const orders = await client.orders(target, { inFlight, limit });
+            return {
+              owner: target,
+              count: orders.length,
+              orders: orders.map(serializeOrder),
+            };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.withdraw",
+        description:
+          "The one unwind verb. SIGNS AND SUBMITS Base transactions. With " +
+          "amountUsdc, withdraws that much of the unlocked balance (a live " +
+          "buyer intent does not block a partial withdrawal). Without it, " +
+          "closes the order fully, pruning expired intents first when " +
+          "needed, and returns the USDC to the agent wallet. Use when a " +
+          "buyer never pays or the agent wants its funds back.",
+        schema: {
+          depositId: depositIdSchema,
+          amountUsdc: usdcAmountSchema.optional(),
+        },
+        queueKey: TRANSACTION_QUEUE,
+        async handler({ depositId, amountUsdc }) {
+          const signer = resolved.wallet;
+          if (!signer) return walletNotConfigured();
+          try {
+            const result = await client.withdraw(depositId, {
+              signer,
+              amount: amountUsdc !== undefined ? usdc(amountUsdc) : undefined,
+            });
+            return { result: withdrawResultToJson(result) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+
+      action({
+        name: "peer-cash.topUp",
+        description:
+          "Add USDC to a live cash-out order. SIGNS AND SUBMITS Base " +
+          "transactions. Same payee, same live oracle market rate; the " +
+          "order keeps its depositId.",
+        schema: {
+          depositId: depositIdSchema,
+          amountUsdc: usdcAmountSchema,
+        },
+        queueKey: TRANSACTION_QUEUE,
+        async handler({ depositId, amountUsdc }) {
+          const signer = resolved.wallet;
+          if (!signer) return walletNotConfigured();
+          try {
+            const result = await client.topUp(depositId, usdc(amountUsdc), {
+              signer,
+            });
+            return { result: topUpResultToJson(result) };
+          } catch (error) {
+            return toActionError(error);
+          }
+        },
+      }),
+    ],
+  });
+}

--- a/packages/peer-cash/tsconfig.json
+++ b/packages/peer-cash/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/packages/peer-cash/tsup.config.ts
+++ b/packages/peer-cash/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+import { tsupConfig } from "../../tsup.config";
+
+export default defineConfig({
+  ...tsupConfig,
+  entry: ["./src/index.ts"],
+  dts: true,
+});


### PR DESCRIPTION
Closes #694.

Adds a Peer Cash extension so Dreams agents can cash out Base USDC to fiat payment apps.

## what is Peer Cash

Peer Cash is our self serve SDK for the Peer P2P protocol (zkp2p). Your wallet deposits USDC into the protocol escrow, a buyer pays you fiat in the payment app and proves it, the protocol releases the USDC. Non-custodial the whole way, priced at the live Chainlink rate with zero spread. No API key is required. It runs in production today on peer.xyz.

## what this PR adds

A new `@daydreamsai/peer-cash` package with eight actions:

- `peer-cash.capabilities`: platforms, currencies, payee format hints, amount bounds
- `peer-cash.fillStats`: 30 day fill counts and median first fill time per platform:currency pair
- `peer-cash.estimate`: oracle rate, receive amount, historical ETA. an estimate, never a locked quote
- `peer-cash.cashout`: create the order (platform, currency, payee, USDC amount), signed by the agent wallet
- `peer-cash.order` / `peer-cash.orders`: live order state by depositId, with a plain language explain and nextActions
- `peer-cash.withdraw`: the one unwind verb. partial with an amount, full close without
- `peer-cash.topUp`: add USDC to a live order

## design notes

I kept to the existing extension idiom:

- `createPeerCashExtension(config)` factory returning `extension({ name, install, actions })`, same shape as `createMcpExtension` in packages/mcp. Package layout copied from packages/hyperliquid (tsup, tsconfig, catalog deps, lerna version).
- errors never throw into the engine. every SDK `CashError` comes back as `{ error: { code, message, retryable, remediation, recovery } }` so the model can read the remediation and decide what to do.
- the three signing actions (`cashout`, `withdraw`, `topUp`) share one `queueKey` so the wallet never signs two Base transactions at once, and none of them set `retry`. reads stay parallel.
- results go through the SDK's zod backed JSON codecs, so nothing stored in working memory carries a bigint. amounts cross the action boundary as decimal USDC strings.
- the wallet is a viem `WalletClient` built from `privateKey` config or `PEER_CASH_PRIVATE_KEY`. without a key the read actions still work and signing actions return `WALLET_NOT_CONFIGURED` instead of throwing.

## config

```ts
createPeerCashExtension({
  environment: "production", // or "preproduction" | "staging"
  referralCode: "ABC123", // optional, six characters
  referrer: "my-app", // optional, analytics only
  privateKey: process.env.PEER_CASH_PRIVATE_KEY, // or just set the env var
  rpcUrl: "https://...", // optional Base RPC override
});
```

config is validated when the factory runs. unknown environment, malformed referral code or malformed private key throw immediately.

## how integrators earn

if you pass `referralCode`, every deposit the extension creates carries a `peer-ref-XXXXXX` ERC-8021 marker. when that liquidity fills, the protocol pays the code owner 50 bps, capped by the Peer service fee. the code to wallet mapping is permanent. no registration, no API key. `referrer` is separate: analytics only attribution, never pays out.

## testing done

from the repo root, matching .github/workflows/ci.yaml:

- `HUSKY=0 bun install --no-scripts` passes, lockfile updated with the new workspace package
- `bun run build:packages` builds every package including peer-cash (ESM plus dts)
- `bun test`: 182 pass, 1 skip, 1 todo, 0 fail (184 tests across 35 files)

package scoped:

- `bun test packages/peer-cash`: 25 pass, 0 fail
- `cd packages/peer-cash && bunx vitest run`: 25 passed (the package test script runner)
- `bunx prettier --check packages/peer-cash`: clean
- `bunx knip`: no findings in the new package

tests inject a mocked `CashClient` and run the real SDK JSON codecs both ways: config validation, amount conversion, signer wiring, queue serialization, happy paths for all eight actions, `CashError` mapping, and the no wallet paths. nothing touches the network.

## links

SDK → https://www.npmjs.com/package/@zkp2p/cash
Docs → https://docs.peer.xyz/developer/peer-cash
Prompt → https://peer.xyz/cash-sdk
Builders Club → https://t.me/zk_p2p/167174

## support

Support is available through the Builders Club above or @andrewwilkinson on X.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daydreamsai/codesmith/daydreams/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789205918&installation_model_id=429520&pr_number=693&repository=daydreamsai%2Fdaydreams&return_to=https%3A%2F%2Fgithub.com%2Fdaydreamsai%2Fdaydreams%2Fpull%2F693&signature=545f0546833413daa0967b784c03d2b538d205286b6071a7d829cacd2e913f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
